### PR TITLE
rust: check for malformed `AuthorityInformationAccess` extension

### DIFF
--- a/src/rust/cryptography-x509-validation/src/policy/extension.rs
+++ b/src/rust/cryptography-x509-validation/src/policy/extension.rs
@@ -247,3 +247,27 @@ pub(crate) mod ca {
         Ok(())
     }
 }
+
+pub(crate) mod common {
+    use cryptography_x509::{
+        certificate::Certificate,
+        extensions::{Extension, SequenceOfAccessDescriptions},
+    };
+
+    use crate::{
+        ops::CryptoOps,
+        policy::{Policy, PolicyError},
+    };
+
+    pub(crate) fn authority_information_access<B: CryptoOps>(
+        _policy: &Policy<'_, B>,
+        _cert: &Certificate<'_>,
+        extn: &Extension<'_>,
+    ) -> Result<(), PolicyError> {
+        // We don't currently do anything useful with these, but we
+        // do check that they're well-formed.
+        let _: SequenceOfAccessDescriptions<'_> = extn.value()?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This is to get the `webpki::malformed_aia` Limbo test passing.