### PR TITLE
validation: make subject non-optional

### DIFF
--- a/src/rust/cryptography-x509-validation/src/lib.rs
+++ b/src/rust/cryptography-x509-validation/src/lib.rs
@@ -442,9 +442,7 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
         let time = asn1::DateTime::new(2023, 7, 10, 0, 0, 0).unwrap();
         let policy: Policy<'_, _> = Policy::new(
             ops,
-            Some(policy::Subject::DNS(
-                DNSName::new("cryptography.io").unwrap(),
-            )),
+            policy::Subject::DNS(DNSName::new("cryptography.io").unwrap()),
             time,
         );
 
@@ -532,9 +530,7 @@ nLRbwHOoq7hHwg==
         let time = asn1::DateTime::new(2023, 7, 10, 0, 0, 0).unwrap();
         let policy: Policy<'_, _> = Policy::new(
             ops,
-            Some(policy::Subject::DNS(
-                DNSName::new("cryptography.io").unwrap(),
-            )),
+            policy::Subject::DNS(DNSName::new("cryptography.io").unwrap()),
             time,
         );
         assert_eq!(

--- a/src/rust/cryptography-x509-validation/src/policy/extension.rs
+++ b/src/rust/cryptography-x509-validation/src/policy/extension.rs
@@ -334,7 +334,8 @@ mod tests {
     use super::{Criticality, ExtensionPolicy};
     use crate::ops::tests::{cert, v1_cert_pem, NullOps};
     use crate::ops::CryptoOps;
-    use crate::policy::{Policy, PolicyError};
+    use crate::policy::{Policy, PolicyError, Subject};
+    use crate::types::DNSName;
     use asn1::{ObjectIdentifier, SimpleAsn1Writable};
     use cryptography_x509::certificate::Certificate;
     use cryptography_x509::extensions::{BasicConstraints, Extension, Extensions};
@@ -394,7 +395,11 @@ mod tests {
         let cert_pem = v1_cert_pem();
         let cert = cert(&cert_pem);
         let ops = NullOps {};
-        let policy = Policy::new(ops, None, epoch());
+        let policy = Policy::new(
+            ops,
+            Subject::DNS(DNSName::new("example.com").unwrap()),
+            epoch(),
+        );
 
         // Test a policy that stipulates that a given extension MUST be present.
         let extension_policy = ExtensionPolicy::present(
@@ -438,7 +443,11 @@ mod tests {
         let cert_pem = v1_cert_pem();
         let cert = cert(&cert_pem);
         let ops = NullOps {};
-        let policy = Policy::new(ops, None, epoch());
+        let policy = Policy::new(
+            ops,
+            Subject::DNS(DNSName::new("example.com").unwrap()),
+            epoch(),
+        );
 
         // Test a policy that stipulates that a given extension CAN be present.
         let extension_policy = ExtensionPolicy::maybe_present(
@@ -474,7 +483,11 @@ mod tests {
         let cert_pem = v1_cert_pem();
         let cert = cert(&cert_pem);
         let ops = NullOps {};
-        let policy = Policy::new(ops, None, epoch());
+        let policy = Policy::new(
+            ops,
+            Subject::DNS(DNSName::new("example.com").unwrap()),
+            epoch(),
+        );
 
         // Test a policy that stipulates that a given extension MUST NOT be present.
         let extension_policy = ExtensionPolicy::not_present(BASIC_CONSTRAINTS_OID);
@@ -506,7 +519,11 @@ mod tests {
         let cert_pem = v1_cert_pem();
         let cert = cert(&cert_pem);
         let ops = NullOps {};
-        let policy = Policy::new(ops, None, epoch());
+        let policy = Policy::new(
+            ops,
+            Subject::DNS(DNSName::new("example.com").unwrap()),
+            epoch(),
+        );
 
         // Test a present policy that stipulates that a given extension MUST be critical.
         let extension_policy = ExtensionPolicy::present(
@@ -534,7 +551,11 @@ mod tests {
         let cert_pem = v1_cert_pem();
         let cert = cert(&cert_pem);
         let ops = NullOps {};
-        let policy = Policy::new(ops, None, epoch());
+        let policy = Policy::new(
+            ops,
+            Subject::DNS(DNSName::new("example.com").unwrap()),
+            epoch(),
+        );
 
         // Test a maybe present policy that stipulates that a given extension MUST be critical.
         let extension_policy = ExtensionPolicy::maybe_present(

--- a/src/rust/src/x509/verify.rs
+++ b/src/rust/src/x509/verify.rs
@@ -174,19 +174,19 @@ fn build_subject_owner(
 fn build_subject<'a>(
     py: pyo3::Python<'_>,
     subject: &'a SubjectOwner,
-) -> pyo3::PyResult<Option<Subject<'a>>> {
+) -> pyo3::PyResult<Subject<'a>> {
     match subject {
         SubjectOwner::DNSName(dns_name) => {
             let dns_name = DNSName::new(dns_name)
                 .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("invalid domain name"))?;
 
-            Ok(Some(Subject::DNS(dns_name)))
+            Ok(Subject::DNS(dns_name))
         }
         SubjectOwner::IPAddress(ip_addr) => {
             let ip_addr = IPAddress::from_bytes(ip_addr.as_bytes(py))
                 .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("invalid IP address"))?;
 
-            Ok(Some(Subject::IP(ip_addr)))
+            Ok(Subject::IP(ip_addr))
         }
     }
 }


### PR DESCRIPTION
This makes `Policy::subject` non-optional at the Rust API level, to match the current Python API. This probably isn't what we want long-term, but for the MVP this removes a few branches that would otherwise be unreachable in the limbo testsuite from the Python API.